### PR TITLE
Update DrawioEditor.php

### DIFF
--- a/src/DrawioEditor.php
+++ b/src/DrawioEditor.php
@@ -139,7 +139,7 @@ class DrawioEditor {
 		if ( $img ) {
 			$img_url_ts = null;
 			$hookRunner = MediaWikiServices::getInstance()->getHookContainer();
-			$hookRunner->run( 'DrawioGetFile', [ &$img, &$latest_is_approved, $parser->getUser() ] );
+			$hookRunner->run( 'DrawioGetFile', [ &$img, &$latest_is_approved, $parser->getUserIdentity() ] );
 			$noApproved = $img === null;
 
 			$img_url_ts = $img->getUrl();


### PR DESCRIPTION
Update to fix error when using extention on MW 1.37.1. Variable has changed from getUser to getUserIdentity

MW error shown "Deprecated: Use of Parser::getUser was deprecated in MediaWiki 1.36. [Called from MediaWiki\Extension\DrawioEditor\DrawioEditor::parse in /www/wwwroot/MWtest/mediawiki-1.37.1/extensions/DrawioEditor/src/DrawioEditor.php at line 142] in /www/wwwroot/MWtest/mediawiki-1.37.1/includes/debug/MWDebug.php on line 375"