### PR TITLE
Updated revision fetch to newer method for mw 1.39

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -4,7 +4,6 @@ namespace MediaWiki\Extension\DrawioEditor;
 
 use Html;
 use MediaWiki\MediaWikiServices;
-use Revision;
 use Title;
 
 class Hooks {
@@ -83,7 +82,7 @@ class Hooks {
 		$aLinks = [];
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 		foreach ( $oRes as $oRow ) {
-			$oRevision = Revision::newFromId( $oRow->rev_id );
+			$oRevision = MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionById( $oRow->rev_id );
 			if ( $oRevision->isCurrent() ) {
 				$title = Title::makeTitle( $oRow->page_namespace, $oRow->page_title );
 				$sLink = $linkRenderer->makeLink( $title );


### PR DESCRIPTION
In some cases there was an error on the file meta page:

```
[cf16fdb3c67312a5f6d02e59] /w/Datei:XYZ.drawio.svg Error: Class "Revision" not found

Backtrace:

from /var/www/copiki/extensions/DrawioEditor/src/Hooks.php(86)
#0 /var/www/copiki/includes/HookContainer/HookContainer.php(338): MediaWiki\Extension\DrawioEditor\Hooks::onImagePageAfterImageLinks(ImagePage, string)
#1 /var/www/copiki/includes/HookContainer/HookContainer.php(137): MediaWiki\HookContainer\HookContainer->callLegacyHook(string, array, array, array)
#2 /var/www/copiki/includes/HookContainer/HookRunner.php(2058): MediaWiki\HookContainer\HookContainer->run(string, array)
#3 /var/www/copiki/includes/page/ImagePage.php(192): MediaWiki\HookContainer\HookRunner->onImagePageAfterImageLinks(ImagePage, string)
#4 /var/www/copiki/includes/actions/ViewAction.php(78): ImagePage->view()
#5 /var/www/copiki/includes/MediaWiki.php(542): ViewAction->show()
#6 /var/www/copiki/includes/MediaWiki.php(322): MediaWiki->performAction(ImagePage, Title)
#7 /var/www/copiki/includes/MediaWiki.php(904): MediaWiki->performRequest()
#8 /var/www/copiki/includes/MediaWiki.php(562): MediaWiki->main()
#9 /var/www/copiki/index.php(50): MediaWiki->run()
#10 /var/www/copiki/index.php(46): wfIndexMain()
#11 {main}
```

The class "Revision" was deprecated in MW 1.37. This upgrades the used class to the newer version of MW 1.39.